### PR TITLE
Fix Contact#upsert method

### DIFF
--- a/lib/expresspigeon-ruby.rb
+++ b/lib/expresspigeon-ruby.rb
@@ -248,7 +248,7 @@ class Contacts
   # :returns: representation of a contact
   #
   def upsert(list_id, contact)
-    post @endpoint, params = {:list_id => list_id, :contact => contact}
+    post @endpoint, params = {:list_id => list_id, :contacts => [contact]}
   end
 
   # Delete single contact. If list_id is not provided, contact will be deleted from system.


### PR DESCRIPTION
Currently `ExpressPigeon::Contact#upsert` doesn't work as expected. My guess is that the [API signature](https://expresspigeon.com/api#contacts_upsert) has changed since the last time the gem was updated. This small patch restores the gem's interface which allows adding or updating one contact at a time via the `upsert` method.

Specs are really, really broken right now so rather than cluttering up this pull request fixing them I opted to leave them broken. Let me know if there is anything you'd like me to change before you merge :smile: 
