### PR TITLE
Add basic AutoResponder support

### DIFF
--- a/lib/express_pigeon/auto_responders.rb
+++ b/lib/express_pigeon/auto_responders.rb
@@ -1,0 +1,47 @@
+module ExpressPigeon
+  class AutoResponders
+    include ExpressPigeon::API
+
+    def initialize
+      @endpoint = 'auto_responders'
+    end
+
+    attr_reader :endpoint
+
+    # Get all autoresponders
+    #
+    # Returns an array of autoresponders.
+    #
+    # Docs: https://expresspigeon.com/api#auto_responders_get_all
+    #
+    def all
+      get endpoint
+    end
+
+    # Start for a contact
+    #
+    # This call starts an autoresponder for a contact.
+    #
+    # :param auto_responder_id: autoresponder id to be started for a contact
+    # :param email:             contact email
+    #
+    # Docs: https://expresspigeon.com/api#auto_responders_start
+    #
+    def start(auto_responder_id, email)
+      post "#{endpoint}/#{auto_responder_id}/start", email: email
+    end
+
+    # Stop for a contact
+    #
+    # This call stops an autoresponder for a contact.
+    #
+    # :param auto_responder_id: autoresponder id to be stopped for a contact
+    # :param email:             contact email
+    #
+    # Docs: https://expresspigeon.com/api#auto_responders_stop
+    #
+    def stop(auto_responder_id, email)
+      post "#{endpoint}/#{auto_responder_id}/stop", email: email
+    end
+  end
+end

--- a/lib/expresspigeon-ruby.rb
+++ b/lib/expresspigeon-ruby.rb
@@ -85,6 +85,10 @@ module ExpressPigeon
     def self.messages
       Messages.new
     end
+
+    def self.auto_responders
+      AutoResponders.new
+    end
   end
 
 end
@@ -110,6 +114,9 @@ class MetaHash < Hash
     @delegate.to_s
   end
 
+  def inspect
+    @delegate.inspect
+  end
 end
 
 class Lists
@@ -316,3 +323,5 @@ class Messages
 
   end
 end
+
+require_relative 'express_pigeon/auto_responders'


### PR DESCRIPTION
This PR adds initial support for ExpressPigeon's [AutoResponder API](https://expresspigeon.com/api#auto_responders). This version adds the following methods:

- `ExpressPigeon::AutoResponders#all` - Get all autoresponders
- `ExpressPigeon::AutoResponders#start` - Start for a contact
- `ExpressPigeon::AutoResponders#stop` - Stop for a contact

Rather than jam another class definition inside `lib/expresspigeon-ruby.rb` I opted to create a new file for the new autoresponder code (`lib/express_pigeon/auto_responders.rb`). I also tried to match the style of other API endpoints as much as possible.

__BONUS__: I've restored the `inspect` method of `MetaHash` which makes responses a little easier to inspect when working in the console:

```ruby
>> ExpressPigeon::API.auto_responders.start(1, "jordan@example.com")
#=> {"status"=>"success", "code"=>200, "message"=>"auto_responder=1 started successfully for contact=jordan@example.com"}
```