### PR TITLE
provide `respond_to`

### DIFF
--- a/lib/expresspigeon-ruby/meta_response.rb
+++ b/lib/expresspigeon-ruby/meta_response.rb
@@ -15,6 +15,10 @@ module ExpressPigeon
       @delegate[m.to_s]
     end
 
+    def respond_to?(m)
+      @delegate.key?(m.to_s)
+    end
+
     def to_s
       @delegate.to_s
     end


### PR DESCRIPTION
`respond_to` is recommended when dynamically allowing methods with `method_missing` to ensure the caller can intelligently guard method calls